### PR TITLE
Update for Go 1.22 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: go test
+        run: GOEXPERIMENT=rangefunc go test ./...

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The following packages are included, with tests demonstrating the iterator implementations:
 
 * [bst](bst) - Binary search tree with traversal iterators
-* [iter](iter) - Core types and functions from the proposals
+* [xiter](xiter) - Functions from the [iterator library proposal](https://github.com/golang/go/issues/61898)
 * [list](list) - Linked list with traversal iterators
 * [maps](maps) - Iterators for keys and values of maps
 * [secret](secret) - Iterators for a custom slice type
@@ -14,19 +14,12 @@ See the related blog post on Medium:
 
 * [A look at iterators in Go](https://medium.com/eureka-engineering/a-look-at-iterators-in-go-f8e86062937c)
 
-## Setup
-
-Follow instructions for installing [gotip](https://pkg.go.dev/golang.org/dl/gotip). (Should not be necessary with Go 1.22.)
-
-```bash
-$ go install golang.org/dl/gotip@latest
-$ gotip download
-```
-
 ## Run
 
-Run tests with `gotip` using the `rangefunc` experiment flag.
+Ensure Go 1.22 is installed.
+
+Run tests using the `rangefunc` experiment flag.
 
 ```bash
-$ GOEXPERIMENT=rangefunc gotip test ./...
+$ GOEXPERIMENT=rangefunc go test ./...
 ```

--- a/bst/bst_test.go
+++ b/bst/bst_test.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/Jimeux/iter/iter"
+	"iter"
 )
 
 func TestBSTIterators(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Jimeux/iter
 
-go 1.21
+go 1.22.0

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Jimeux/iter/iter"
+	"github.com/Jimeux/iter/xiter"
 )
 
 func TestListIterators(t *testing.T) {
@@ -37,13 +37,13 @@ func TestListIterators(t *testing.T) {
 		}
 	})
 	t.Run("FilterMapReduce", func(t *testing.T) {
-		filter := iter.Filter(func(i int) bool {
+		filter := xiter.Filter(func(i int) bool {
 			return i > 1
 		}, l.All)
-		mapped := iter.Map(func(i int) string {
+		mapped := xiter.Map(func(i int) string {
 			return strconv.Itoa(i) + "!"
 		}, filter)
-		got := iter.Reduce(nil, func(sum []string, s string) []string {
+		got := xiter.Reduce(nil, func(sum []string, s string) []string {
 			return append(sum, s)
 		}, mapped)
 

--- a/maps/maps.go
+++ b/maps/maps.go
@@ -1,6 +1,6 @@
 package maps
 
-import "github.com/Jimeux/iter/iter"
+import "iter"
 
 // Keys returns an iterator over the keys in m.
 func Keys[M ~map[K]V, K comparable, V any](m M) iter.Seq[K] {

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Jimeux/iter/iter"
+	"github.com/Jimeux/iter/xiter"
 )
 
 func TestInts(t *testing.T) {
@@ -46,13 +46,13 @@ func TestInts(t *testing.T) {
 		}
 	})
 	t.Run("FilterMapReduce", func(t *testing.T) {
-		filter := iter.Filter(func(s Int) bool {
+		filter := xiter.Filter(func(s Int) bool {
 			return s.Visible
 		}, ints.All)
-		mapped := iter.Map(func(s Int) string {
+		mapped := xiter.Map(func(s Int) string {
 			return strconv.Itoa(s.Val) + "!"
 		}, filter)
-		got := iter.Reduce(nil, func(sum []string, s string) []string {
+		got := xiter.Reduce(nil, func(sum []string, s string) []string {
 			return append(sum, s)
 		}, mapped)
 

--- a/xiter/iter.go
+++ b/xiter/iter.go
@@ -1,20 +1,12 @@
-// Package iter is based on the current proposal for x/exp/xiter,
+// Package xiter is based on the current proposal for x/exp/xiter,
 // a possible new package with iterator adapters.
 // See [https://github.com/golang/go/issues/61898].
-package iter
+package xiter
 
-// Seq is an iterator over sequences of individual values.
-// When called as seq(yield), seq calls yield(v) for each value v in the sequence,
-// stopping early if yield returns false.
-type Seq[V any] func(yield func(V) bool)
-
-// Seq2 is an iterator over sequences of pairs of values, most commonly key-value pairs.
-// When called as seq(yield), seq calls yield(k, v) for each pair (k, v) in the sequence,
-// stopping early if yield returns false.
-type Seq2[K, V any] func(yield func(K, V) bool)
+import "iter"
 
 // Concat returns an iterator over the concatenation of the sequences.
-func Concat[V any](seqs ...Seq[V]) Seq[V] {
+func Concat[V any](seqs ...iter.Seq[V]) iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for _, seq := range seqs {
 			seq(yield)
@@ -23,7 +15,7 @@ func Concat[V any](seqs ...Seq[V]) Seq[V] {
 }
 
 // Concat2 returns an iterator over the concatenation of the sequences.
-func Concat2[K, V any](seqs ...Seq2[K, V]) Seq2[K, V] {
+func Concat2[K, V any](seqs ...iter.Seq2[K, V]) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for _, seq := range seqs {
 			seq(yield)
@@ -33,7 +25,7 @@ func Concat2[K, V any](seqs ...Seq2[K, V]) Seq2[K, V] {
 
 // Filter returns an iterator over seq that only includes
 // the values v for which f(v) is true.
-func Filter[V any](f func(V) bool, seq Seq[V]) Seq[V] {
+func Filter[V any](f func(V) bool, seq iter.Seq[V]) iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for v := range seq {
 			if f(v) && !yield(v) {
@@ -45,7 +37,7 @@ func Filter[V any](f func(V) bool, seq Seq[V]) Seq[V] {
 
 // Filter2 returns an iterator over seq that only includes
 // the pairs k, v for which f(k, v) is true.
-func Filter2[K, V any](f func(K, V) bool, seq Seq2[K, V]) Seq2[K, V] {
+func Filter2[K, V any](f func(K, V) bool, seq iter.Seq2[K, V]) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for k, v := range seq {
 			if f(k, v) && !yield(k, v) {
@@ -56,7 +48,7 @@ func Filter2[K, V any](f func(K, V) bool, seq Seq2[K, V]) Seq2[K, V] {
 }
 
 // Map returns an iterator over f applied to seq.
-func Map[T, U any](f func(T) U, seq Seq[T]) Seq[U] {
+func Map[T, U any](f func(T) U, seq iter.Seq[T]) iter.Seq[U] {
 	return func(yield func(U) bool) {
 		for in := range seq {
 			if !yield(f(in)) {
@@ -67,7 +59,7 @@ func Map[T, U any](f func(T) U, seq Seq[T]) Seq[U] {
 }
 
 // Map2 returns an iterator over f applied to seq.
-func Map2[K1, V1, K2, V2 any](f func(K1, V1) (K2, V2), seq Seq2[K1, V1]) Seq2[K2, V2] {
+func Map2[K1, V1, K2, V2 any](f func(K1, V1) (K2, V2), seq iter.Seq2[K1, V1]) iter.Seq2[K2, V2] {
 	return func(yield func(K2, V2) bool) {
 		for k, v := range seq {
 			if !yield(f(k, v)) {
@@ -82,7 +74,7 @@ func Map2[K1, V1, K2, V2 any](f func(K1, V1) (K2, V2), seq Seq2[K1, V1]) Seq2[K2
 // and then returns the final sum.
 // For example, if iterating over seq yields v1, v2, v3,
 // Reduce returns f(f(f(sum, v1), v2), v3).
-func Reduce[Sum, V any](sum Sum, f func(Sum, V) Sum, seq Seq[V]) Sum {
+func Reduce[Sum, V any](sum Sum, f func(Sum, V) Sum, seq iter.Seq[V]) Sum {
 	for v := range seq {
 		sum = f(sum, v)
 	}
@@ -94,7 +86,7 @@ func Reduce[Sum, V any](sum Sum, f func(Sum, V) Sum, seq Seq[V]) Sum {
 // and then returns the final sum.
 // For example, if iterating over seq yields (k1, v1), (k2, v2), (k3, v3)
 // Reduce returns f(f(f(sum, k1, v1), k2, v2), k3, v3).
-func Reduce2[Sum, K, V any](sum Sum, f func(Sum, K, V) Sum, seq Seq2[K, V]) Sum {
+func Reduce2[Sum, K, V any](sum Sum, f func(Sum, K, V) Sum, seq iter.Seq2[K, V]) Sum {
 	for k, v := range seq {
 		sum = f(sum, k, v)
 	}


### PR DESCRIPTION
## Summary

* Remove gotip setup instructions 
* Remove `Seq` types and use standard library `iter` package
* Rename `iter` package to `xiter`